### PR TITLE
Partial Flushing Implementation for MIPS

### DIFF
--- a/cpu.h
+++ b/cpu.h
@@ -156,7 +156,7 @@ extern u8 ram_translation_cache[RAM_TRANSLATION_CACHE_SIZE];
 extern u8 *rom_translation_ptr;
 extern u8 *ram_translation_ptr;
 
-#define MAX_TRANSLATION_GATES 8
+#define MAX_TRANSLATION_GATES 16
 
 extern u32 idle_loop_target_pc;
 extern u32 translation_gate_targets;
@@ -165,6 +165,7 @@ extern u32 translation_gate_target_pc[MAX_TRANSLATION_GATES];
 extern u32 rom_branch_hash[ROM_BRANCH_HASH_SIZE];
 
 void partial_flush_ram_full(u32 address);
+void partial_flush_ram_full_dma(u32 address);
 void flush_translation_cache_rom(void);
 void flush_translation_cache_ram(void);
 void dump_translation_cache(void);

--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -29,10 +29,6 @@
 #include <kernel.h>
 #endif
 
-#ifdef SF2000
-void xlog(const char *fmt, ...);
-#endif
-
 u8 *last_rom_translation_ptr = NULL;
 u8 *last_ram_translation_ptr = NULL;
 
@@ -94,6 +90,8 @@ typedef struct
   u32 branch_target;
   u8 *branch_source;
 } block_exit_type;
+
+extern u8 bit_count[256];
 
 // Div (6) and DivArm (7)
 #define is_div_swi(swinum) (((swinum) & 0xFE) == 0x06)
@@ -290,21 +288,16 @@ void translate_icache_sync() {
   check_pc_region(pc);                                                        \
   opcode = address32(pc_address_block, (pc & 0x7FFF));                        \
   condition = block_data[block_data_position].condition;                      \
+  u32 has_condition_header = 0;                                               \
                                                                               \
   if((condition != last_condition) || (condition >= 0x20))                    \
   {                                                                           \
-    if((last_condition & 0x0F) != 0x0E)                                       \
-    {                                                                         \
-      generate_branch_patch_conditional(backpatch_address, translation_ptr);  \
-    }                                                                         \
-                                                                              \
-    last_condition = condition;                                               \
-                                                                              \
     condition &= 0x0F;                                                        \
                                                                               \
     if(condition != 0x0E)                                                     \
     {                                                                         \
       arm_conditional_block_header();                                         \
+      has_condition_header = 1;                                               \
     }                                                                         \
   }                                                                           \
   emit_trace_arm_instruction(pc);                                             \
@@ -1743,6 +1736,10 @@ void translate_icache_sync() {
     }                                                                         \
   }                                                                           \
                                                                               \
+  if(has_condition_header)                                                    \
+  {                                                                           \
+    generate_branch_patch_conditional(backpatch_address, translation_ptr);    \
+  }                                                                           \
   pc += 4                                                                     \
 
 #define arm_flag_status()                                                     \
@@ -2498,12 +2495,16 @@ void translate_icache_sync() {
 // of the RAM CACHE (grows like a stack). For simplicity we start tags at 0xFFFF
 // and grow like a stack.
 
+// INITIAL_TOP_TAG is 0xFFFD.  0xFFFF signifies an Unconditional Branch (end of normal block)
+//
 #define LAST_TAG_NUM       0x0101
-#define INITIAL_TOP_TAG    0xFFFF
+#define INITIAL_TOP_TAG    0xFFFD
 #define CODE_TAG_BLOCK16   0x0101
 #define CODE_TAG_BLOCK32   0x01010101
+#define UB_16		   0xFFFF
+#define UB_32		   0xFFFFFFFF
 
-#define VALID_TAG(tagn) (tagn > LAST_TAG_NUM)
+#define VALID_TAG(tagn) (tagn > LAST_TAG_NUM && tagn <= INITIAL_TOP_TAG)
 
 #define allocate_tag_arm(location) {   \
   location[0] = ram_block_tag;         \
@@ -2566,16 +2567,17 @@ u8 function_cc *block_lookup_translate_##type(u32 pc)                         \
                                   : (u16 *)(iwram + (pc & 0x7FFF));           \
       ramtag_type* trentry;                                                   \
       /* Allocate a tag if not a valid one, and initialize header */          \
+      /* Set offsets to 1 initially, as setting to/checking zero will result in first block of each flush iteration being recompiled */          \
       if (!VALID_TAG(*tagp)) {                                                \
         allocate_tag_##type(tagp);                                            \
         trentry = get_ram_tag(*tagp);                                         \
-        trentry->offset_arm = 0;                                              \
-        trentry->offset_thumb = 0;                                            \
+        trentry->offset_arm = 1;                                              \
+        trentry->offset_thumb = 1;                                            \
       } else {                                                                \
         trentry = get_ram_tag(*tagp);                                         \
       }                                                                       \
                                                                               \
-      if (!trentry->offset_##type) {                                          \
+      if (trentry->offset_##type ==1) {                                          \
         bool result;                                                          \
         u8 *blkptr = ram_translation_ptr + block_prologue_size;               \
         trentry->offset_##type = blkptr - ram_translation_cache;              \
@@ -2655,7 +2657,7 @@ u8 function_cc *block_lookup_address_dual(u32 pc)
 u8 function_cc *block_lookup_address_arm(u32 pc)
 {
   unsigned i;
-  for (i = 0; i < 2; i++) {
+  for (i = 0; i < 4; i++) {
     u8 *ret = block_lookup_translate_arm(pc);
     if (ret) {
       translate_icache_sync();
@@ -2663,21 +2665,23 @@ u8 function_cc *block_lookup_address_arm(u32 pc)
     }
   }
 
-  // PERFORMANCE: Disable logging in hot path
+  printf("bad jump %x (%x)\n", pc, reg[REG_PC]);
+  fflush(stdout);
   return NULL;
 }
 
 u8 function_cc *block_lookup_address_thumb(u32 pc)
 {
   unsigned i;
-  for (i = 0; i < 2; i++) {
+  for (i = 0; i < 4; i++) {
     u8 *ret = block_lookup_translate_thumb(pc);
     if (ret) {
       translate_icache_sync();
       return ret;
     }
   }
-  // PERFORMANCE: Disable logging in hot path
+  printf("bad jump %x (%x)\n", pc, reg[REG_PC]);
+  fflush(stdout);
   return NULL;
 }
 
@@ -2886,11 +2890,15 @@ u8 function_cc *block_lookup_address_thumb(u32 pc)
   }                                                                           \
 }                                                                             \
 
-#define MAX_BLOCK_SIZE   2048   // 4/8KiB blocks max for SF2000
-#define MAX_EXITS          64   // Increased for SF2000 performance
+#define MAX_BLOCK_SIZE 8192
+#define arm_MAX_BLOCK_SIZE 8192
+#define thumb_MAX_BLOCK_SIZE 8192
+
+#define MAX_EXITS      256
+#define arm_MAX_EXITS      256
+#define thumb_MAX_EXITS      256
 
 block_data_type block_data[MAX_BLOCK_SIZE];
-block_exit_type block_exits[MAX_EXITS];
 
 #define smc_write_arm_yes() {                                                 \
   intptr_t offset = (pc < 0x03000000) ? 0x40000 : -0x8000;                    \
@@ -2909,20 +2917,98 @@ block_exit_type block_exits[MAX_EXITS];
       CODE_TAG_BLOCK16;                                                       \
   }                                                                           \
 }
-
 #define smc_write_arm_no()                                                    \
 
 #define smc_write_thumb_no()                                                  \
 
+#define arm_ub() {                                          \
+  intptr_t offset = (pc < 0x03000000) ? 0x40000 : -0x8000;                    \
+  intptr_t mask = 0x7FFF;                 \
+  if(address32(pc_address_block, ((block_end_pc - 4) & mask) + offset) <= CODE_TAG_BLOCK32)        \
+    address32(pc_address_block, ((block_end_pc - 4) & mask) + offset) =           \
+      UB_32;                                                       \
+}
+
+#define thumb_ub() {                                        \
+  intptr_t offset = (pc < 0x03000000) ? 0x40000 : -0x8000;                    \
+  intptr_t mask = 0x7FFF;                       \
+  if(address16(pc_address_block, ((block_end_pc - 2) & mask) + offset)  <= CODE_TAG_BLOCK16)        \
+    address16(pc_address_block, ((block_end_pc - 2)  & mask) + offset) =           \
+      UB_16;                                                       \
+}
+
+/*
+ * Inserts Value into a sorted Array of unique values (or doesn't), of
+ * size Size.
+ * If Value was already present, then the old size is returned, and no
+ * insertions are made. Otherwise, Value is inserted into Array at the
+ * proper position to maintain its total order, and Size + 1 is returned.
+ */
+static u32 InsertUniqueSorted(u32* Array, u32 Value, u32 Size)
+{
+	// Gather the insertion index with a binary search.
+	s32 Min = 0, Max = Size - 1;
+	while (Min < Max) {
+		s32 Mid = Min + (Max - Min) / 2;
+		if (Array[Mid] < Value)
+			Min = Mid + 1;
+		else
+			Max = Mid;
+	}
+
+	// Insert at Min.
+	// Min == Size means we just insert at the end...
+	if (Min == Size) {
+		Array[Size] = Value;
+		return Size + 1;
+	}
+	// ... otherwise it's either already in the array...
+	else if (Array[Min] == Value) {
+		return Size;
+	}
+	// ... or we need to move things.
+	else {
+		memmove(&Array[Min + 1], &Array[Min], Size - Min);
+		Array[Min] = Value;
+		return Size + 1;
+	}
+}
+
+/*
+ * Searches for the given Value in the given sorted Array of size Size.
+ * If found, the index in the Array of the first element having the given
+ * Value is returned.
+ * Otherwise, -1 is returned.
+ */
+static s32 BinarySearch(u32* Array, u32 Value, u32 Size)
+{
+	s32 Min = 0, Max = Size - 1;
+	while (Min < Max) {
+		s32 Mid = Min + (Max - Min) / 2;
+		if (Array[Mid] < Value)
+			Min = Mid + 1;
+		else
+			Max = Mid;
+	}
+
+	if (Min == Max && Array[Min] == Value)
+		return Min;
+	else
+		return -1;
+}
+
 #define scan_block(type, smc_write_op)                                        \
 {                                                                             \
   __label__ block_end;                                                        \
+  u8 continue_block = 1;                                                      \
+  u32 branch_targets_sorted[MAX_EXITS];                                       \
+  u32 sorted_branch_count = 0;                                                \
   /* Find the end of the block */                                             \
   do                                                                          \
   {                                                                           \
     check_pc_region(block_end_pc);                                            \
-    smc_write_##type##_##smc_write_op();                                      \
     type##_load_opcode();                                                     \
+    smc_write_##type##_##smc_write_op();                                      \
     type##_flag_status();                                                     \
                                                                               \
     if(type##_exit_point)                                                     \
@@ -2933,6 +3019,9 @@ block_exit_type block_exits[MAX_EXITS];
         __label__ no_direct_branch;                                           \
         type##_branch_target();                                               \
         block_exits[block_exit_position].branch_target = branch_target;       \
+	if(!ram_region)							      \
+          sorted_branch_count = InsertUniqueSorted(branch_targets_sorted,     \
+          branch_target, sorted_branch_count);                                \
         block_exit_position++;                                                \
                                                                               \
         /* Give the branch target macro somewhere to bail if it turns out to  \
@@ -2945,6 +3034,9 @@ block_exit_type block_exits[MAX_EXITS];
       if(type##_opcode_swi)                                                   \
       {                                                                       \
         block_exits[block_exit_position].branch_target = 0x00000008;          \
+	if(!ram_region)							      \
+        sorted_branch_count = InsertUniqueSorted(branch_targets_sorted,       \
+          0x00000008, sorted_branch_count);                                \
         block_exit_position++;                                                \
       }                                                                       \
                                                                               \
@@ -2954,42 +3046,41 @@ block_exit_type block_exits[MAX_EXITS];
       if(type##_opcode_unconditional_branch)                                  \
       {                                                                       \
         /* Check to see if any prior block exits branch after here,           \
-           if so don't end the block. Starts from the top and works           \
-           down because the most recent branch is most likely to              \
-           join after the end (if/then form) */                               \
-        for(i = block_exit_position - 2; i >= 0; i--)                         \
-        {                                                                     \
-          if(block_exits[i].branch_target == block_end_pc)                    \
-            break;                                                            \
-        }                                                                     \
-                                                                              \
-        if(i < 0)                                                             \
-          break;                                                              \
+           if so don't end the block. For efficiency, but to also keep the    \
+           correct order of the scanned branches for code emission, this is   \
+           using a separate sorted array with unique branch_targets. */       \
+        if (ram_region || BinarySearch(branch_targets_sorted, block_end_pc,   \
+          sorted_branch_count) == -1)                                         \
+          continue_block = 0;                                                 \
+       if (ram_region)								\
+          type##_ub();								\
       }                                                                       \
-      if(block_exit_position == MAX_EXITS)                                    \
-        break;                                                                \
+      if(block_exit_position == type##_MAX_EXITS)                             \
+        continue_block = 0;                                                   \
     }                                                                         \
     else                                                                      \
     {                                                                         \
       type##_set_condition(condition);                                        \
     }                                                                         \
+    block_data[block_data_position].update_cycles = 0;                        \
+    block_data_position++;                                                    \
                                                                               \
     for(i = 0; i < translation_gate_targets; i++)                             \
     {                                                                         \
       if(block_end_pc == translation_gate_target_pc[i])                       \
-        goto block_end;                                                       \
+      {                                                                       \
+        translation_gate_required = 1;                                        \
+        continue_block = 0;                                                   \
+      }                                                                       \
     }                                                                         \
                                                                               \
-    block_data[block_data_position].update_cycles = 0;                        \
-    block_data_position++;                                                    \
-    if((block_data_position == MAX_BLOCK_SIZE) ||                             \
+    if((block_data_position == type##_MAX_BLOCK_SIZE) ||                      \
      (block_end_pc == 0x3007FF0) || (block_end_pc == 0x203FFFF0))             \
     {                                                                         \
-      break;                                                                  \
+      continue_block = 0;                                                     \
     }                                                                         \
-  } while(1);                                                                 \
+  } while(continue_block);                                                    \
                                                                               \
-  block_end:;                                                                 \
 }                                                                             \
 
 #define arm_fix_pc()                                                          \
@@ -3031,7 +3122,7 @@ bool translate_block_arm(u32 pc, bool ram_region)
   u8 *translation_cache_limit = NULL;
   s32 i;
   u32 flag_status;
-  block_exit_type external_block_exits[MAX_EXITS];
+  block_exit_type block_exits[MAX_EXITS];
   generate_block_extra_vars_arm();
   arm_fix_pc();
 
@@ -3051,6 +3142,8 @@ bool translate_block_arm(u32 pc, bool ram_region)
   }
 
   generate_block_prologue();
+
+  u8 translation_gate_required = 0; /* gets updated by scan_block */          \
 
   /* This is a function because it's used a lot more than it might seem (all
      of the data processing functions can access it), and its expansion was
@@ -3077,6 +3170,12 @@ bool translate_block_arm(u32 pc, bool ram_region)
     }
   }
 
+ // if (!ram_region) {                         
+    /* If we're translating in RAM, expect to be called VERY often. Thus,     
+     * don't spend time eliminating flags for code that will just go to       
+     * waste in a millisecond. */             
+  //arm_dead_flag_eliminate();
+  //}
   arm_dead_flag_eliminate();
 
   block_exit_position = 0;
@@ -3127,7 +3226,8 @@ bool translate_block_arm(u32 pc, bool ram_region)
 
   /* Unconditionally generate translation targets. In case we hit one or
      in the unlikely case that block was too big (and not finalized) */
-  generate_translation_gate(arm);
+  //if (translation_gate_required)
+    generate_translation_gate(arm);
 
   for(i = 0; i < block_exit_position; i++)
   {
@@ -3145,12 +3245,23 @@ bool translate_block_arm(u32 pc, bool ram_region)
     }
     else
     {
-      /* External branch, save for later */
-      external_block_exits[external_block_exit_position].branch_target =
-       branch_target;
-      external_block_exits[external_block_exit_position].branch_source =
-       block_exits[i].branch_source;
+      /* This branch exits the basic block. If the branch target is in a      
+       * read-only code area (the BIOS or the Game Pak ROM), we can link the  
+       * block statically below. THIS BEHAVIOUR NEEDS TO BE DUPLICATED IN THE 
+       * EMITTER. Please see your emitter's generate_branch_no_cycle_update   
+       * macro for more information. */                                       
+      if (branch_target < 0x00004000 /* BIOS */                               
+      || (branch_target >= 0x08000000 && branch_target < 0x0E000000))         
+     {                                                                       
+       /* External branch, save for later. Simply compact the external         
+       * exits to the beginning of the same array. */                         
+      if (i != external_block_exit_position)                                  
+      {                                                                       
+        memcpy(&block_exits[external_block_exit_position], &block_exits[i],   
+          sizeof(block_exit_type));                                           
+      }                                                                       
       external_block_exit_position++;
+     }
     }
   }
 
@@ -3161,7 +3272,7 @@ bool translate_block_arm(u32 pc, bool ram_region)
 
   for(i = 0; i < external_block_exit_position; i++)
   {
-    branch_target = external_block_exits[i].branch_target;
+    branch_target = block_exits[i].branch_target;
     if(branch_target == 0x00000008)
       translation_target = bios_swi_entrypoint;
     else
@@ -3169,7 +3280,7 @@ bool translate_block_arm(u32 pc, bool ram_region)
     if (!translation_target)
       return false;
     generate_branch_patch_unconditional(
-      external_block_exits[i].branch_source, translation_target);
+      block_exits[i].branch_source, translation_target);
   }
   return true;
 }
@@ -3195,7 +3306,7 @@ bool translate_block_thumb(u32 pc, bool ram_region)
   u8 *translation_cache_limit = NULL;
   s32 i;
   u32 flag_status;
-  block_exit_type external_block_exits[MAX_EXITS];
+  block_exit_type block_exits[MAX_EXITS];
   generate_block_extra_vars_thumb();
   thumb_fix_pc();
 
@@ -3219,6 +3330,8 @@ bool translate_block_thumb(u32 pc, bool ram_region)
      of the data processing functions can access it), and its expansion was
      massacreing the compiler. */
 
+  u8 translation_gate_required = 0; /* gets updated by scan_block */          
+
   if(ram_region)
   {
     scan_block(thumb, yes);
@@ -3240,6 +3353,12 @@ bool translate_block_thumb(u32 pc, bool ram_region)
     }
   }
 
+ // if (!ram_region) {                         
+    /* If we're translating in RAM, expect to be called VERY often. Thus,     
+     * don't spend time eliminating flags for code that will just go to       
+     * waste in a millisecond. */             
+  //thumb_dead_flag_eliminate();
+  //}
   thumb_dead_flag_eliminate();
 
   block_exit_position = 0;
@@ -3284,7 +3403,8 @@ bool translate_block_thumb(u32 pc, bool ram_region)
 
   /* Unconditionally generate translation targets. In case we hit one or
      in the unlikely case that block was too big (and not finalized) */
-  generate_translation_gate(thumb);
+  //if (translation_gate_required)                                              
+    generate_translation_gate(thumb);
 
   for(i = 0; i < block_exit_position; i++)
   {
@@ -3302,12 +3422,23 @@ bool translate_block_thumb(u32 pc, bool ram_region)
     }
     else
     {
-      /* External branch, save for later */
-      external_block_exits[external_block_exit_position].branch_target =
-       branch_target;
-      external_block_exits[external_block_exit_position].branch_source =
-       block_exits[i].branch_source;
+      /* This branch exits the basic block. If the branch target is in a      
+       * read-only code area (the BIOS or the Game Pak ROM), we can link the  
+       * block statically below. THIS BEHAVIOUR NEEDS TO BE DUPLICATED IN THE 
+       * EMITTER. Please see your emitter's generate_branch_no_cycle_update   
+       * macro for more information. */                                       
+      if (branch_target < 0x00004000 /* BIOS */                               
+      || (branch_target >= 0x08000000 && branch_target < 0x0E000000))         
+     {                                                                       
+       /* External branch, save for later. Simply compact the external         
+       * exits to the beginning of the same array. */                         
+      if (i != external_block_exit_position)                                  
+      {                                                                       
+        memcpy(&block_exits[external_block_exit_position], &block_exits[i],   
+          sizeof(block_exit_type));                                           
+      }                                                                       
       external_block_exit_position++;
+     }
     }
   }
 
@@ -3318,7 +3449,7 @@ bool translate_block_thumb(u32 pc, bool ram_region)
 
   for(i = 0; i < external_block_exit_position; i++)
   {
-    branch_target = external_block_exits[i].branch_target;
+    branch_target = block_exits[i].branch_target;
     if(branch_target == 0x00000008)
       translation_target = bios_swi_entrypoint;
     else
@@ -3326,7 +3457,7 @@ bool translate_block_thumb(u32 pc, bool ram_region)
     if (!translation_target)
       return false;
     generate_branch_patch_unconditional(
-      external_block_exits[i].branch_source, translation_target);
+      block_exits[i].branch_source, translation_target);
   }
   return true;
 }
@@ -3415,25 +3546,13 @@ void flush_dynarec_caches(void)
   flush_translation_cache_ram();
 }
 
-void partial_flush_ram_full(u32 address)
+void partial_flush_ram_full_dma(u32 address)
 {
-#if defined(MIPS_ARCH)
-  /* PERFORMANCE: Most 2D games don't use SMC - reduce flush frequency for soft FPU MIPS */
-  static u32 flush_counter = 0;
-  #ifdef SF2000
-  if ((++flush_counter & 0x7) != 0) {
-    return; // Skip 87.5% of flushes for SF2000 performance
-  }
-  #else
-  if ((++flush_counter & 0x3) != 0) {
-    return; // Skip 75% of flushes for performance
-  }
-  #endif
-#endif
-
   u8 *smc_data;
   u8 *ewram_smc_data = &ewram[0x40000];
   u8 *iwram_smc_data = iwram;
+
+  // printf("SMC Data Address: %x \n", address);
 
   switch (address >> 24)
   {
@@ -3442,6 +3561,7 @@ void partial_flush_ram_full(u32 address)
       break;
     case 0x03: /* IWRAM */
       smc_data = iwram_smc_data + (address & 0x7FFE);
+//      printf("SMC Data Address: %x \n", smc_data);
       break;
     default:   /* no smc_data */
       return;
@@ -3469,11 +3589,9 @@ void partial_flush_ram_full(u32 address)
     smc_data = smc_data - 2;
     if (smc_data < smc_data_area)
       smc_data = smc_data_area_end - 2; // Wrap to the end
-    if (*((u16*) smc_data) != 0)
-      *((u16*) smc_data) = 0;
-    else 
-      {
-      break; }
+    if (*((u16*) smc_data) == 0 || *((u16*) smc_data) == UB_16)
+       break; 
+     *((u16*) smc_data) = 0;
   }
 
   smc_data = smc_data_right;
@@ -3483,9 +3601,108 @@ void partial_flush_ram_full(u32 address)
     smc_data = smc_data + 2;
     if (smc_data == smc_data_area_end)
       smc_data = smc_data_area; // Wrap to the beginning
-    if (*((u16*) smc_data) != 0)
-      *((u16*) smc_data) = 0;
-    else
+    if (*((u16*) smc_data) == 0)
       break;
+      *((u16*) smc_data) = 0;
+  }
+
+}
+
+void partial_flush_ram_full(u32 address)
+{
+  u8 *smc_data;
+  u8 *ewram_smc_data = &ewram[0x40000];
+  u8 *iwram_smc_data = iwram;
+
+  switch (address >> 24)
+  {
+    case 0x02: /* EWRAM */
+      smc_data = ewram_smc_data + (address & 0x3FFFE);
+      break;
+    case 0x03: /* IWRAM */
+      smc_data = iwram_smc_data + (address & 0x7FFE);
+//      printf("SMC Data Address: %x \n", smc_data);
+      break;
+    default:   /* no smc_data */
+      return;
+  }
+
+  u8 *smc_data_area, *smc_data_area_end, *smc_data_right ;
+  smc_data_right = smc_data; // Save this pointer to go to the right later
+
+  switch (address >> 24)
+  {
+    case 0x02: /* EWRAM */
+      smc_data_area = ewram_smc_data;
+      smc_data_area_end = ewram_smc_data + 0x40000;
+      break;
+    case 0x03: /* IWRAM */
+      smc_data_area = iwram_smc_data;
+      smc_data_area_end = iwram_smc_data + 0x8000;
+      break;
+  }
+  
+  *((u16*) smc_data) = 0;
+
+  // ******* TRANSLATION GATES ********
+
+  u8 y = 0;
+ 
+  // Align the address to ARM instruction interval and set to previous instruction
+  u32 translation_gate_dyn = ((address & ~0x03) - 4);
+ 
+  // Check if the SMC address already appears in our Translation Gate list
+  for(y= 0; y < translation_gate_targets; y++) {
+ 
+    //printf("translation gate proposed entry : %x \n", translation_gate_dyn);
+    if(translation_gate_target_pc[y] == translation_gate_dyn)
+     break;
+ 
+  }
+
+  // If it doesn't exist, y = translation_gate_targets
+  if(y == translation_gate_targets) {
+    //printf("translation gate proposed entry : %x  y: %x \n", translation_gate_targets, translation_gate_dyn);
+    //fflush(stdout);
+    translation_gate_target_pc[translation_gate_targets] = translation_gate_dyn;
+    
+    if(translation_gate_targets == MAX_TRANSLATION_GATES) {
+      // This is a circular array, so let's set it back to 3 so that we overwrite the oldest entries
+      // except for the ones specified in gba_over (ToDo: need to actually determine how many are specified)
+      translation_gate_targets = 0;
+    } 
+    else {
+    translation_gate_targets++;
+    }
+  }
+
+  //if(*((u16*) smc_data) > ram_block_tag){
+   // ramtag_type* trentry_flush;                                                   
+   // trentry_flush = get_ram_tag(*((u16*) smc_data) | 0x1);
+  //  trentry_flush->offset_arm = 1;
+  //  trentry_flush->offset_thumb = 1;
+    //printf("Flush Block Start: %x , SMC Data value %x \n", trentry_flush->block_start, *((u16*) smc_data));
+  //}
+
+  while (1)
+  {
+    smc_data = smc_data - 2;
+    if (smc_data < smc_data_area)
+      smc_data = smc_data_area_end - 2; // Wrap to the end
+    if (*((u16*) smc_data) == 0 || *((u16*) smc_data) == UB_16)
+       break; 
+     *((u16*) smc_data) = 0;
+  }
+
+  smc_data = smc_data_right;
+
+  while (1)
+  {
+    smc_data = smc_data + 2;
+    if (smc_data == smc_data_area_end)
+      smc_data = smc_data_area; // Wrap to the beginning
+    if (*((u16*) smc_data) == 0)
+      break;
+      *((u16*) smc_data) = 0;
   }
 }

--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -91,7 +91,7 @@ typedef struct
   u8 *branch_source;
 } block_exit_type;
 
-extern u8 bit_count[256];
+extern const u8 bit_count[256];
 
 // Div (6) and DivArm (7)
 #define is_div_swi(swinum) (((swinum) & 0xFE) == 0x06)

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -2118,12 +2118,6 @@ const dma_region_type dma_region_map[17] =
 #define dma_read_ext(type, tfsize)                                            \
   read_value = read_memory##tfsize(type##_ptr)                                \
 
-#define dma_write_iwram(type, tfsize)                                         \
-  address##tfsize(iwram + 0x8000, type##_ptr & 0x7FFF) =                      \
-                                          eswap##tfsize(read_value);          \
-  if (address##tfsize(iwram, type##_ptr & 0x7FFF))                            \
-    alerts |= CPU_ALERT_SMC;                                                  \
-
 #define dma_write_vram(type, tfsize) {                                        \
   u32 wraddr = type##_ptr & 0x1FFFF;                                          \
   if (wraddr >= 0x18000) wraddr -= 0x8000;                                    \
@@ -2142,10 +2136,23 @@ const dma_region_type dma_region_map[17] =
 #define dma_write_ext(type, tfsize)                                           \
   write_memory##tfsize(type##_ptr, read_value)                                \
 
+#define dma_write_iwram(type, tfsize)                                         \
+  if(address##tfsize(iwram + 0x8000, type##_ptr & 0x7FFF) != eswap##tfsize(read_value)) {          \
+    address##tfsize(iwram + 0x8000, type##_ptr & 0x7FFF) = eswap##tfsize(read_value);               \
+    if(address##tfsize(iwram, type##_ptr & 0x7FFF) != 0)   {                         \
+        partial_flush_ram_full_dma(type##_ptr);                                            \
+        alerts |= CPU_ALERT_SMC;                                                \
+    }															\
+  }															\
+
 #define dma_write_ewram(type, tfsize)                                         \
-  address##tfsize(ewram, type##_ptr & 0x3FFFF) = eswap##tfsize(read_value);   \
-  if (address##tfsize(ewram, (type##_ptr & 0x3FFFF) + 0x40000))               \
-    alerts |= CPU_ALERT_SMC;                                                  \
+  if(address##tfsize(ewram, type##_ptr & 0x3FFFF) != eswap##tfsize(read_value)) {       \
+    address##tfsize(ewram, type##_ptr & 0x3FFFF) = eswap##tfsize(read_value);   \
+    if(address##tfsize(ewram, (type##_ptr & 0x3FFFF) + 0x40000) != 0)	{	        \
+         partial_flush_ram_full_dma(type##_ptr);                                            \
+         alerts |= CPU_ALERT_SMC;                                                \
+    }															\
+  }	
 
 #define print_line()                                                          \
   dma_print(src_op, dest_op, tfsize);                                         \

--- a/mips/mips_emit.h
+++ b/mips/mips_emit.h
@@ -2359,12 +2359,12 @@ static void emit_pmemst_stub(
       mips_emit_addu(reg_temp, reg_rv, reg_temp); // SMC lives after the ewram
       // Prepare reg_a0 so that we can pass address to partial_flush_ram_full
       mips_emit_lui(reg_rv, 0x200);
-      mips_emit_addu(reg_rv, reg_rv, reg_a0);    // a0 should now be original address
+      mips_emit_addu(reg_a0, reg_rv, reg_a0);    // a0 should now be original address
     } else {
       mips_emit_addiu(reg_temp, reg_rv, 0x8000); // -32KB is the addr of the SMC buffer
       // Prepare reg_a0 so that we can pass address to partial_flush_ram_full
       mips_emit_lui(reg_rv, 0x300);
-      mips_emit_addu(reg_rv, reg_rv, reg_a0);    // a0 should now be original address
+      mips_emit_addu(reg_a0, reg_rv, reg_a0);    // a0 should now be original address
     }
     if (realsize == 2) {
       mips_emit_lw(reg_temp, reg_temp, base_addr);

--- a/mips/mips_emit.h
+++ b/mips/mips_emit.h
@@ -231,14 +231,32 @@ u32 arm_to_mips_reg[] =
   *((u32 *)(dest)) = (mips_opcode_j << 26) |                                  \
    ((mips_absolute_offset(offset)) & 0x3FFFFFF)                               \
 
-#define generate_branch_no_cycle_update(writeback_location, new_pc)           \
+#define generate_branch_no_cycle_update(type,writeback_location, new_pc)      \
   if(pc == idle_loop_target_pc)                                               \
   {                                                                           \
     generate_load_pc(reg_a0, new_pc);                                         \
     mips_emit_lui(reg_cycles, 0);                                             \
     generate_function_call_swap_delay(mips_update_gba);                       \
-    mips_emit_j_filler(writeback_location);                                   \
-    mips_emit_nop();                                                          \
+      /* This uses variables from cpu_asm.c's translate_block_builder /       \
+       * translate_block_arm / translate_block_thumb functions. Basically,    \
+       * if we're emitting a jump towards inside the same basic block, or if  \
+       * the branch target is in a read-only area (BIOS or ROM), we can link  \
+       * statically and backpatch all we like, but if we're emitting a branch \
+       * towards a basic block that's in writable (GBA) memory, that block is \
+       * OFF LIMITS and that branch must be issued indirectly and resolved at \
+       * branch time. This allows us to efficiently clear SOME of the RAM     \
+       * code cache after SOME of it has been modified. Ideally, that's one   \
+       * basic block. */                                                      \
+      if ((new_pc >= block_start_pc && new_pc < block_end_pc)                 \
+       || (new_pc <  0x00004000) /* BIOS */                                   \
+       || (new_pc >= 0x08000000 && new_pc < 0x0A000000) /* Game Pak ROM */) { \
+        mips_emit_j_filler(writeback_location);                               \
+        mips_emit_nop();                                                      \
+      }                                                                       \
+      else {                                                                  \
+        generate_load_imm(reg_a0, new_pc);                                    \
+        generate_indirect_branch_no_cycle_update(type);                       \
+      }                                                                       \
   }                                                                           \
   else                                                                        \
   {                                                                           \
@@ -246,13 +264,22 @@ u32 arm_to_mips_reg[] =
     mips_emit_bltzal(reg_cycles,                                              \
      mips_relative_offset(translation_ptr, update_trampoline));               \
     generate_swap_delay();                                                    \
-    mips_emit_j_filler(writeback_location);                                   \
-    mips_emit_nop();                                                          \
+      /* Same as above. */                                                    \
+      if ((new_pc >= block_start_pc && new_pc < block_end_pc)                 \
+       || (new_pc <  0x00004000) /* BIOS */                                   \
+       || (new_pc >= 0x08000000 && new_pc < 0x0A000000) /* Game Pak ROM */) { \
+        mips_emit_j_filler(writeback_location);                               \
+        mips_emit_nop();                                                      \
+      }                                                                       \
+      else {                                                                  \
+        generate_load_imm(reg_a0, new_pc);                                    \
+        generate_indirect_branch_no_cycle_update(type);                       \
+      }                                                                       \
   }                                                                           \
 
-#define generate_branch_cycle_update(writeback_location, new_pc)              \
+#define generate_branch_cycle_update(type,writeback_location, new_pc)         \
   generate_cycle_update();                                                    \
-  generate_branch_no_cycle_update(writeback_location, new_pc)                 \
+  generate_branch_no_cycle_update(type,writeback_location, new_pc)            \
 
 // a0 holds the destination
 
@@ -502,7 +529,8 @@ u32 arm_to_mips_reg[] =
 // Returns a new rm if it redirects it (which will happen on most of these
 // cases)
 
-#define generate_load_rm_sh(rm, flags_op)                                     \
+#define generate_load_rm_sh_builder(flags_op)                                 \
+u32 generate_load_rm_sh_##flags_op(u32 rm)                                    \
 {                                                                             \
   switch((opcode >> 4) & 0x07)                                                \
   {                                                                           \
@@ -547,6 +575,8 @@ u32 arm_to_mips_reg[] =
       break;                                                                  \
     }                                                                         \
   }                                                                           \
+                                                                              \
+  return rm;                                                                  \
 }                                                                             \
 
 #define generate_block_extra_vars()                                           \
@@ -556,8 +586,10 @@ u32 arm_to_mips_reg[] =
 
 #define generate_block_extra_vars_arm()                                       \
   generate_block_extra_vars();                                                \
-
-#define generate_load_offset_sh(rm)                                           \
+  generate_load_rm_sh_builder(flags);                                         \
+  generate_load_rm_sh_builder(no_flags);                                      \
+                                                                              \
+  u32 generate_load_offset_sh(u32 rm)                                         \
   {                                                                           \
     switch((opcode >> 5) & 0x03)                                              \
     {                                                                         \
@@ -582,6 +614,7 @@ u32 arm_to_mips_reg[] =
         break;                                                                \
       }                                                                       \
     }                                                                         \
+    return rm;                                                                \
   }                                                                           \
 
 #define generate_indirect_branch_arm()                                        \
@@ -724,17 +757,19 @@ u32 execute_spsr_restore_body(u32 address)
       break;                                                                  \
   }                                                                           \
 
-#define generate_branch()                                                     \
+/* This is used in the code emission phase, when the branch target is
+  * known. The branch source is written into block_exits here. */
+ #define generate_branch(type)                                                \
 {                                                                             \
   if(condition == 0x0E)                                                       \
   {                                                                           \
-    generate_branch_cycle_update(                                             \
+    generate_branch_cycle_update(type,                                        \
      block_exits[block_exit_position].branch_source,                          \
      block_exits[block_exit_position].branch_target);                         \
   }                                                                           \
   else                                                                        \
   {                                                                           \
-    generate_branch_no_cycle_update(                                          \
+    generate_branch_no_cycle_update(type,                                     \
      block_exits[block_exit_position].branch_source,                          \
      block_exits[block_exit_position].branch_target);                         \
   }                                                                           \
@@ -1059,11 +1094,11 @@ u32 execute_spsr_restore_body(u32 address)
   arm_decode_data_proc_reg(opcode);                                           \
   if(check_generate_c_flag)                                                   \
   {                                                                           \
-    generate_load_rm_sh(rm, flags);                                           \
+    rm = generate_load_rm_sh_flags(rm);                                       \
   }                                                                           \
   else                                                                        \
   {                                                                           \
-    generate_load_rm_sh(rm, no_flags);                                        \
+    rm = generate_load_rm_sh_no_flags(rm);                                    \
   }                                                                           \
                                                                               \
   arm_op_check_##load_op();                                                   \
@@ -1072,7 +1107,7 @@ u32 execute_spsr_restore_body(u32 address)
 
 #define arm_generate_op_reg(name, load_op)                                    \
   arm_decode_data_proc_reg(opcode);                                           \
-  generate_load_rm_sh(rm, no_flags);                                          \
+  rm = generate_load_rm_sh_no_flags(rm);                                      \
   arm_op_check_##load_op();                                                   \
   generate_op_##name##_reg(arm_to_mips_reg[rd], arm_to_mips_reg[rn],          \
    arm_to_mips_reg[rm])                                                       \
@@ -1270,7 +1305,7 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
 
 #define arm_data_trans_reg(adjust_op, adjust_dir)                             \
   arm_decode_data_trans_reg();                                                \
-  generate_load_offset_sh(rm);                                                \
+  rm = generate_load_offset_sh(rm);                                           \
   arm_access_memory_reg_##adjust_op(adjust_dir)                               \
 
 #define arm_data_trans_imm(adjust_op, adjust_dir)                             \
@@ -1303,14 +1338,13 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
   generate_load_reg_pc(reg_a1, i, 8);                                         \
   generate_function_call_swap_delay(execute_aligned_store32)                  \
 
-#define arm_block_memory_final_load(writeback_type)                           \
+#define arm_block_memory_final_load()                                         \
   arm_block_memory_load()                                                     \
 
-#define arm_block_memory_final_store(writeback_type)                          \
+#define arm_block_memory_final_store()                                        \
   generate_load_pc(reg_a2, (pc + 4));                                         \
-  generate_load_reg(reg_a1, i);                                               \
-  arm_block_memory_writeback_post_store(writeback_type);                      \
-  generate_function_call_swap_delay(execute_store_u32);                       \
+  mips_emit_jal(mips_absolute_offset(execute_store_u32));                     \
+  generate_load_reg(reg_a1, i)                                                \
 
 #define arm_block_memory_adjust_pc_store()                                    \
 
@@ -1361,15 +1395,13 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
 
 // Only emit writeback if the register is not in the list
 
-#define arm_block_memory_writeback_post_load(writeback_type)
-#define arm_block_memory_writeback_pre_load(writeback_type)                   \
+#define arm_block_memory_writeback_load(writeback_type)                       \
   if(!((reg_list >> rn) & 0x01))                                              \
   {                                                                           \
     arm_block_memory_writeback_##writeback_type();                            \
   }                                                                           \
 
-#define arm_block_memory_writeback_pre_store(writeback_type)
-#define arm_block_memory_writeback_post_store(writeback_type)                 \
+#define arm_block_memory_writeback_store(writeback_type)                      \
   arm_block_memory_writeback_##writeback_type()                               \
 
 #define arm_block_memory(access_type, offset_type, writeback_type, s_bit)     \
@@ -1380,7 +1412,7 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
   u32 base_reg = arm_to_mips_reg[rn];                                         \
                                                                               \
   arm_block_memory_offset_##offset_type();                                    \
-  arm_block_memory_writeback_pre_##access_type(writeback_type);               \
+  arm_block_memory_writeback_##access_type(writeback_type);                   \
                                                                               \
   if(rn == REG_SP)                                                            \
   {                                                                           \
@@ -1406,7 +1438,6 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
       }                                                                       \
     }                                                                         \
                                                                               \
-    arm_block_memory_writeback_post_##access_type(writeback_type);            \
     arm_block_memory_sp_adjust_pc_##access_type();                            \
   }                                                                           \
   else                                                                        \
@@ -1426,7 +1457,7 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
         }                                                                     \
         else                                                                  \
         {                                                                     \
-          arm_block_memory_final_##access_type(writeback_type);               \
+          arm_block_memory_final_##access_type();                             \
           break;                                                              \
         }                                                                     \
       }                                                                       \
@@ -1775,7 +1806,7 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
 #define thumb_conditional_branch(condition)                                   \
 {                                                                             \
   generate_condition_##condition();                                           \
-  generate_branch_no_cycle_update(                                            \
+  generate_branch_no_cycle_update(thumb,                                      \
    block_exits[block_exit_position].branch_source,                            \
    block_exits[block_exit_position].branch_target);                           \
   generate_branch_patch_conditional(backpatch_address, translation_ptr);      \
@@ -1786,11 +1817,11 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
   generate_condition();                                                       \
 
 #define arm_b()                                                               \
-  generate_branch()                                                           \
+  generate_branch(arm)                                                        \
 
 #define arm_bl()                                                              \
   generate_load_pc(reg_r14, (pc + 4));                                        \
-  generate_branch()                                                           \
+  generate_branch(arm)                                                        \
 
 #define arm_bx()                                                              \
   arm_decode_branchx(opcode);                                                 \
@@ -1801,17 +1832,19 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
 #define arm_swi()                                                             \
   generate_load_pc(reg_a0, (pc + 4));                                         \
   generate_function_call_swap_delay(execute_swi);                             \
-  generate_branch()                                                           \
+  generate_branch(arm)                                                        \
 
+/* This is used in the code emission phase, when the branch target is
+  * known. The branch source is written into block_exits here. */
 #define thumb_b()                                                             \
-  generate_branch_cycle_update(                                               \
+  generate_branch_cycle_update(thumb,                                         \
    block_exits[block_exit_position].branch_source,                            \
    block_exits[block_exit_position].branch_target);                           \
   block_exit_position++                                                       \
 
 #define thumb_bl()                                                            \
   generate_load_pc(reg_r14, ((pc + 2) | 0x01));                               \
-  generate_branch_cycle_update(                                               \
+  generate_branch_cycle_update(thumb,                                         \
    block_exits[block_exit_position].branch_source,                            \
    block_exits[block_exit_position].branch_target);                           \
   block_exit_position++                                                       \
@@ -1864,10 +1897,12 @@ u32 execute_store_cpsr_body(u32 _cpsr, u32 address)
   #define emit_trace_arm_instruction(pc)
 #endif
 
+/* This is used in the code emission phase, when the branch target is
+  * known. The branch source is written into block_exits here. */
 #define thumb_swi()                                                           \
   generate_load_pc(reg_a0, (pc + 2));                                         \
   generate_function_call_swap_delay(execute_swi);                             \
-  generate_branch_cycle_update(                                               \
+  generate_branch_cycle_update(arm, /* SWI target == ARM */                   \
    block_exits[block_exit_position].branch_source,                            \
    block_exits[block_exit_position].branch_target);                           \
   block_exit_position++                                                       \
@@ -2307,14 +2342,29 @@ static void emit_pmemst_stub(
     mips_emit_addu(reg_rv, reg_rv, reg_a0);    // Adds to base addr
   }
 
+  // Store the data (do write first so we can use reg_rv in SMC check to do lui)
+  if (realsize == 2) {
+    mips_emit_sw(reg_a1, reg_rv, base_addr);
+  } else if (realsize == 1) {
+    mips_emit_sh(reg_a1, reg_rv, base_addr);
+  } else {
+    mips_emit_sb(reg_a1, reg_rv, base_addr);
+  }
+
   // Generate SMC write and tracking
   // TODO: Should we have SMC checks here also for aligned?
   if (meminfo->check_smc && !aligned) {
     if (region == 2) {
       mips_emit_lui(reg_temp, 0x40000 >> 16);
       mips_emit_addu(reg_temp, reg_rv, reg_temp); // SMC lives after the ewram
+      // Prepare reg_a0 so that we can pass address to partial_flush_ram_full
+      mips_emit_lui(reg_rv, 0x200);
+      mips_emit_addu(reg_rv, reg_rv, reg_a0);    // a0 should now be original address
     } else {
       mips_emit_addiu(reg_temp, reg_rv, 0x8000); // -32KB is the addr of the SMC buffer
+      // Prepare reg_a0 so that we can pass address to partial_flush_ram_full
+      mips_emit_lui(reg_rv, 0x300);
+      mips_emit_addu(reg_rv, reg_rv, reg_a0);    // a0 should now be original address
     }
     if (realsize == 2) {
       mips_emit_lw(reg_temp, reg_temp, base_addr);
@@ -2327,15 +2377,9 @@ static void emit_pmemst_stub(
     // Local-jump to the smc_write (which lives at offset:0)
     mips_emit_b(bne, reg_zero, reg_temp, branch_offset(&rom_translation_cache[SMC_WRITE_OFF]));
   }
+  // nop in delay slot (could do store here instead of above if we can work out register usage)
+  mips_emit_nop();
 
-  // Store the data (delay slot from the SMC branch)
-  if (realsize == 2) {
-    mips_emit_sw(reg_a1, reg_rv, base_addr);
-  } else if (realsize == 1) {
-    mips_emit_sh(reg_a1, reg_rv, base_addr);
-  } else {
-    mips_emit_sb(reg_a1, reg_rv, base_addr);
-  }
 
   // Post processing store:
   // Signal that OAM was updated
@@ -2809,5 +2853,4 @@ u32 execute_arm_translate(u32 cycles) {
 }
 
 #endif
-
 

--- a/mips/mips_stub.S
+++ b/mips/mips_stub.S
@@ -367,11 +367,11 @@ lookup_pc_noflags:
   jr $2                                # jump to result
   nop
 
-
+# $4 (reg_a0) should already contain the SMC address
 defsymbl(smc_write)
   sw $6, REG_PC($16)              # save PC
   save_registers
-  cfncall flush_translation_cache_ram, 4
+  cfncall partial_flush_ram_full, 10
   b lookup_pc_noflags
   lw $1, REG_CPSR($16)            # (delay)
 
@@ -610,6 +610,7 @@ fnptrs:
   .long execute_store_cpsr_body        # 7
   .long process_cheats                 # 8
   .long check_and_raise_interrupts     # 9
+  .long partial_flush_ram_full	       # 10
 
 #if !defined(MMAP_JIT_CACHE)
 
@@ -629,4 +630,3 @@ defsymbl(ram_translation_cache)
   .space RAM_TRANSLATION_CACHE_SIZE
 
 #endif
-


### PR DESCRIPTION
This fully implements Partial Flushing for dynarec with Dynamic Translation Gates.  I've tested this on ARM and it gives the best balance of a good speed increase as well as minimizing associated issues (e.g. there is a further optimisation which involved adding an Unconditional Block marker to the shadow RAM in the Translation Gate routine - this speeds up Mario Tennis but causes Duke Nukem to crash when going in-game.  So I have left this out). 